### PR TITLE
docs: update links

### DIFF
--- a/src/links/README.md
+++ b/src/links/README.md
@@ -3,7 +3,7 @@ title: 'Links'
 layout: Page
 ---
 
-* [Aquariuslt blog](https://blog.aquariuslt.com)
+* [Aquariuslt blog](https://zexo.dev)
 * [Lz's blog](https://lz5z.com)
 
 Submit pull request to [Github](https://github.com/wxsms/blog/tree/master/src/links/README.md) if you wish to add friend links here.


### PR DESCRIPTION
migration domain `https//blog.aquariuslt.com` to `https://zexo.dev` with zeit now smart-cdn.

@wxsms hi kary gor, please help review and update